### PR TITLE
fix(instrument): ensure logger includes span context

### DIFF
--- a/instrument/reconciler.go
+++ b/instrument/reconciler.go
@@ -22,13 +22,12 @@ func NewInstrumentedReconciler(t Instrumenter, r reconcile.TypedReconciler[recon
 }
 
 func (t *InstrumentedReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	logger := t.NewLogger(ctx)
-	ctx = logf.IntoContext(ctx, logger)
-
 	ctxPtr, _ := t.GetContextForRequest(req)
-
 	ctx, span := t.StartSpan(ctxPtr, ctx, "reconcile")
 	defer span.End()
+
+	logger := t.NewLogger(ctx)
+	ctx = logf.IntoContext(ctx, logger)
 
 	result, err := t.internalReconciler.Reconcile(ctx, req)
 	if err != nil {

--- a/instrument/reconciler_test.go
+++ b/instrument/reconciler_test.go
@@ -3,6 +3,7 @@ package instrument
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -10,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -103,6 +105,50 @@ func TestInstrumentedReconciler_Reconcile_WithError(t *testing.T) {
 
 	if err != expectedError {
 		t.Errorf("expected error %v, got %v", expectedError, err)
+	}
+
+	if result != expectedResult {
+		t.Errorf("expected result %+v, got %+v", expectedResult, result)
+	}
+}
+
+func TestInstrumentedReconciler_LoggerContext(t *testing.T) {
+	ctrlr := gomock.NewController(t)
+	defer ctrlr.Finish()
+
+	mockInstrumenter := mocks.NewMockInstrumenter(ctrlr)
+	mockReconciler := mocks.NewMockTypedReconciler[reconcile.Request](ctrlr)
+
+	instrumentedReconciler := NewInstrumentedReconciler(mockInstrumenter, mockReconciler)
+
+	expectedResult := reconcile.Result{Requeue: false}
+	ctx := context.Background()
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "test-namespace",
+			Name:      "test-name",
+		},
+	}
+
+	mockInstrumenter.EXPECT().GetContextForRequest(req).Return(&ctx, true)
+	mockInstrumenter.EXPECT().NewLogger(gomock.Any()).Return(logr.New(logf.NullLogSink{}))
+	mockInstrumenter.EXPECT().StartSpan(gomock.Any(), gomock.Any(), gomock.Any()).Return(ctx, trace.SpanFromContext(ctx))
+
+	mockReconciler.EXPECT().Reconcile(gomock.Any(), req).DoAndReturn(func(localCtx context.Context, req reconcile.Request) (reconcile.Result, error) {
+		logger := logf.FromContext(localCtx)
+
+		switch logger.GetSink().(type) {
+		default:
+			return expectedResult, fmt.Errorf("logger sink is not logf.NullLogSink")
+		case logf.NullLogSink:
+			return expectedResult, nil
+		}
+	})
+	mockInstrumenter.EXPECT().Cleanup(&ctx, req)
+
+	result, err := instrumentedReconciler.Reconcile(ctx, req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
 
 	if result != expectedResult {


### PR DESCRIPTION
Fix #29 by moving the IntoContext after having created the span, this ensures the logger in context actually contains the span

A new test case has been added in `reconciler_test.go` to validate that the bug has been fixed.