### PR TITLE
feat: add WithGVKFunc to UntypedDependencyBuilder

### DIFF
--- a/dependency_untyped.go
+++ b/dependency_untyped.go
@@ -10,28 +10,28 @@ import (
 
 type UntypedDependency[CustomResourceType client.Object, ContextType Context[CustomResourceType]] struct {
 	*Dependency[CustomResourceType, ContextType, *unstructured.Unstructured]
-	gvk schema.GroupVersionKind
+	gvkF func() schema.GroupVersionKind
 }
 
 var _ GenericDependency[client.Object, Context[client.Object]] = &UntypedDependency[client.Object, Context[client.Object]]{}
 
 func (c *UntypedDependency[CustomResourceType, ContextType]) New() client.Object {
 	out := &unstructured.Unstructured{}
-	out.SetGroupVersionKind(c.gvk)
+	out.SetGroupVersionKind(c.gvkF())
 	return out
 }
 
 func (c *UntypedDependency[CustomResourceType, ContextType]) Kind() string {
-	return fmt.Sprintf("Untyped%s", c.gvk.Kind)
+	return fmt.Sprintf("Untyped%s", c.gvkF().Kind)
 }
 
 func (c *UntypedDependency[CustomResourceType, ContextType]) Set(obj client.Object) {
 	if c.output == nil {
 		c.output = &unstructured.Unstructured{}
-		c.output.SetGroupVersionKind(c.gvk)
+		c.output.SetGroupVersionKind(c.gvkF())
 	}
 
 	unstructuredObj := obj.(*unstructured.Unstructured)
 	*c.output = *unstructuredObj
-	c.output.SetGroupVersionKind(c.gvk)
+	c.output.SetGroupVersionKind(c.gvkF())
 }

--- a/dependency_untyped_builder.go
+++ b/dependency_untyped_builder.go
@@ -42,7 +42,7 @@ import (
 //		Build()
 type UntypedDependencyBuilder[CustomResourceType client.Object, ContextType Context[CustomResourceType]] struct {
 	inner *DependencyBuilder[CustomResourceType, ContextType, *unstructured.Unstructured]
-	gvk   schema.GroupVersionKind
+	gvkF  func() schema.GroupVersionKind
 }
 
 // NewUntypedDependencyBuilder creates a new UntypedDependencyBuilder for constructing
@@ -77,7 +77,9 @@ type UntypedDependencyBuilder[CustomResourceType client.Object, ContextType Cont
 func NewUntypedDependencyBuilder[CustomResourceType client.Object, ContextType Context[CustomResourceType]](ctx ContextType, gvk schema.GroupVersionKind) *UntypedDependencyBuilder[CustomResourceType, ContextType] {
 	return &UntypedDependencyBuilder[CustomResourceType, ContextType]{
 		inner: NewDependencyBuilder(ctx, &unstructured.Unstructured{}),
-		gvk:   gvk,
+		gvkF: func() schema.GroupVersionKind {
+			return gvk
+		},
 	}
 }
 
@@ -106,7 +108,7 @@ func (b *UntypedDependencyBuilder[CustomResourceType, ContextType]) WithKeyFunc(
 func (b *UntypedDependencyBuilder[CustomResourceType, ContextType]) Build() *UntypedDependency[CustomResourceType, ContextType] {
 	return &UntypedDependency[CustomResourceType, ContextType]{
 		Dependency: b.inner.Build(),
-		gvk:        b.gvk,
+		gvkF:       b.gvkF,
 	}
 }
 
@@ -318,5 +320,41 @@ func (b *UntypedDependencyBuilder[CustomResourceType, ContextType]) WithWaitForR
 //	.WithAddManagedByAnnotation(true) // Mark dependency relationship for debugging
 func (b *UntypedDependencyBuilder[CustomResourceType, ContextType]) WithAddManagedByAnnotation(add bool) *UntypedDependencyBuilder[CustomResourceType, ContextType] {
 	b.inner = b.inner.WithAddManagedByAnnotation(add)
+	return b
+}
+
+// WithGVKFunc specifies a function that dynamically determines the GroupVersionKind
+// of the untyped dependency at runtime.
+//
+// This is useful when the exact GVK is not known at compile time or depends on
+// configuration in the custom resource. The function is evaluated during dependency
+// resolution, allowing the target resource type to change based on the reconciliation
+// context.
+//
+// Common use cases:
+//   - Selecting different API versions based on the custom resource's spec
+//   - Targeting different resource kinds depending on feature flags or configuration
+//   - Supporting multiple CRD versions with a single dependency definition
+//
+// If not called, the static GVK passed to NewUntypedDependencyBuilder is used.
+//
+// Example:
+//
+//	.WithGVKFunc(func() schema.GroupVersionKind {
+//		if ctx.Data.UseV2API {
+//			return schema.GroupVersionKind{
+//				Group:   "example.com",
+//				Version: "v2",
+//				Kind:    "Database",
+//			}
+//		}
+//		return schema.GroupVersionKind{
+//			Group:   "example.com",
+//			Version: "v1",
+//			Kind:    "Database",
+//		}
+//	})
+func (b *UntypedDependencyBuilder[CustomResourceType, ContextType]) WithGVKFunc(f func() schema.GroupVersionKind) *UntypedDependencyBuilder[CustomResourceType, ContextType] {
+	b.gvkF = f
 	return b
 }

--- a/framework_primitives_test.go
+++ b/framework_primitives_test.go
@@ -213,7 +213,9 @@ func TestDependencyMethodsCoverTypedAndUntypedVariants(t *testing.T) {
 		Dependency: &Dependency[*corev1.ConfigMap, Context[*corev1.ConfigMap], *unstructured.Unstructured]{
 			output: &unstructured.Unstructured{},
 		},
-		gvk: gvk,
+		gvkF: func() schema.GroupVersionKind {
+			return gvk
+		},
 	}
 
 	untypedCreated, ok := untypedDependency.New().(*unstructured.Unstructured)


### PR DESCRIPTION
 ### Problem

`UntypedDependencyBuilder` required the `schema.GroupVersionKind` to be fixed at build time via `NewUntypedDependencyBuilder`. This prevented controller authors from selecting different API versions, resource kinds, or CRD groups dynamically based on the reconciliation context.
                                                                                                                                          
### Solution 

Refactor both `UntypedDependencyBuilder` and `UntypedDependency` to store GVK as a function `func() schema.GroupVersionKind` rather than a static `schema.GroupVersionKind` value. The constructor `NewUntypedDependencyBuilder` continues to accept a static GVK but now wraps it in a closure, preserving full backward      
compatibility. A new builder method `WithGVKFunc` allows users to override this with custom runtime logic.                                                                                                                                                                                                             

All internal call sites (New, Kind, Set) now evaluate the function lazily, ensuring the latest GVK is always used during reconciliation.  

### API Changes                                                                                                                                                                                                                                                                                                          

- `UntypedDependencyBuilder.WithGVKFunc` Sets a dynamic function to determine the target resource's GroupVersionKind at runtime. If not called, the static GVK passed to `NewUntypedDependencyBuilder` is used (default behavior unchanged).                                                                                                                                                                                                                                                                                                                                                                                                           
 - Internal field `gvk` renamed to `gvkF` in `UntypedDependencyBuilder` and `UntypedDependency`