### PR TITLE
fix: make NewResolveDependencyStep return a custom step result

### DIFF
--- a/step_dependency.go
+++ b/step_dependency.go
@@ -11,6 +11,61 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type DependencyStepResult struct {
+	earlyReturn  bool
+	err          error
+	requeueAfter time.Duration
+	wasFound     bool
+}
+
+var _ StepResult = DependencyStepResult{}
+
+func (result DependencyStepResult) WasFound() bool {
+	return result.wasFound
+}
+
+// Error returns the underlying step error, if any.
+func (result DependencyStepResult) Error() error {
+	return result.err
+}
+
+// RequeueAfter returns the requested requeue duration, if any.
+func (result DependencyStepResult) RequeueAfter() time.Duration {
+	return result.requeueAfter
+}
+
+// IsEarlyReturn reports whether the step requested an early return without error.
+func (result DependencyStepResult) IsEarlyReturn() bool {
+	return result.earlyReturn
+}
+
+// IsSuccess reports whether the step completed without error, requeue, or early return.
+func (result DependencyStepResult) IsSuccess() bool {
+	return !result.ShouldReturn()
+}
+
+// ShouldReturn reports whether reconciliation should stop after this step.
+func (result DependencyStepResult) ShouldReturn() bool {
+	return result.err != nil || result.requeueAfter > 0 || result.earlyReturn
+}
+
+// FromSubStep clears early return semantics when bubbling a nested step result upward.
+func (result DependencyStepResult) FromSubStep() StepResult {
+	result.earlyReturn = false
+	return result
+}
+
+// Normal converts the step result into a controller-runtime reconcile result.
+func (result DependencyStepResult) Normal() (ctrl.Result, error) {
+	if result.err != nil {
+		return ctrl.Result{}, result.err
+	}
+	if result.requeueAfter > 0 {
+		return ctrl.Result{RequeueAfter: result.requeueAfter}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
 func NewResolveDependencyStep[
 	ControllerResourceType ControllerCustomResource,
 	ContextType Context[ControllerResourceType],
@@ -26,7 +81,9 @@ func NewResolveDependencyStep[
 
 			funcResult := func() StepResult {
 				if err := dependency.BeforeReconcile(ctx); err != nil {
-					return ResultInError(errors.Wrap(err, "failed to run BeforeReconcile hook"))
+					return DependencyStepResult{
+						err: errors.Wrap(err, "failed to run BeforeReconcile hook"),
+					}
 				}
 
 				cr := ctx.GetCustomResource()
@@ -37,14 +94,20 @@ func NewResolveDependencyStep[
 				err := reconciler.Get(ctx, depKey, dep)
 				if err != nil {
 					if client.IgnoreNotFound(err) != nil {
-						return ResultInError(errors.Wrap(err, "failed to get dependency resource"))
+						return DependencyStepResult{
+							err: errors.Wrap(err, "failed to get dependency resource"),
+						}
 					}
 
 					if IsFinalizing(cr) || dependency.IsOptional() {
-						return ResultSuccess()
+						return DependencyStepResult{
+							wasFound: false,
+						}
 					}
 
-					return ResultRequeueIn(30 * time.Second)
+					return DependencyStepResult{
+						requeueAfter: 30 * time.Second,
+					}
 				}
 				cleanDep := dep.DeepCopyObject().(client.Object)
 
@@ -53,15 +116,21 @@ func NewResolveDependencyStep[
 				if IsFinalizing(cr) {
 					changed, err := RemoveManagedBy(dep, cr, reconciler.Scheme())
 					if client.IgnoreNotFound(err) != nil {
-						return ResultInError(err)
+						return DependencyStepResult{
+							err: err,
+						}
 					}
 					if changed {
 						if err := reconciler.Patch(ctx, dep, client.MergeFrom(cleanDep)); err != nil {
-							return ResultInError(err)
+							return DependencyStepResult{
+								err: err,
+							}
 						}
 					}
 
-					return ResultSuccess()
+					return DependencyStepResult{
+						wasFound: true,
+					}
 				}
 
 				if dependency.ShouldAddManagedByAnnotation() {
@@ -76,24 +145,34 @@ func NewResolveDependencyStep[
 
 					changed, err := AddManagedBy(dep, cr, reconciler.Scheme())
 					if err != nil {
-						return ResultInError(err)
+						return DependencyStepResult{
+							err: err,
+						}
 					}
 					if changed {
 						if err := reconciler.Patch(ctx, dep, client.MergeFrom(cleanDep)); err != nil {
-							return ResultInError(err)
+							return DependencyStepResult{
+								err: err,
+							}
 						}
 					}
 				}
 
 				if dependency.ShouldWaitForReady() && !dependency.IsReady() {
-					return ResultRequeueIn(30 * time.Second)
+					return DependencyStepResult{
+						requeueAfter: 30 * time.Second,
+					}
 				}
 
-				return ResultSuccess()
+				return DependencyStepResult{
+					wasFound: true,
+				}
 			}()
 
 			if err := dependency.AfterReconcile(ctx, dep); err != nil {
-				return ResultInError(errors.Wrap(err, "failed to run AfterReconcile hook"))
+				return DependencyStepResult{
+					err: errors.Wrap(err, "failed to run AfterReconcile hook"),
+				}
 			}
 
 			return funcResult


### PR DESCRIPTION
### Problem                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                      
`NewResolveDependencyStep` previously relied on the generic helper constructors (`ResultSuccess`, `ResultInError`, `ResultRequeueIn`) to build its `StepResult`. These helpers return a plain `basicStepResult`, which carries no information about whether the underlying dependency resource was actually located on the cluster. This made it impossible for downstream logic (or wrappers around the step) to know whether a "success" outcome meant the dependency was found and processed versus the dependency was missing but optional/finalizing.                                                                                      
                                                                                                                                                                                                                                                                                                                      
### Solution                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                      
Introduced a dedicated `dependencyStepResult` type that satisfies the `StepResult` interface but adds an internal `wasFound` field. `NewResolveDependencyStep` now constructs and returns this concrete type directly, preserving all existing error, requeue, and early-return semantics while also recording whether the `reconciler.Get` actually located the dependency resource.                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                      
### API Changes                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                      
- `NewResolveDependencyStep` now returns a `DependencyStepResult` instead of a plain `basicStepResult`. The public `StepResult` interface is unchanged, so callers still consume the result through `Error`, `RequeueAfter`, `IsSuccess`, `ShouldReturn`, etc.                                                                       
- Added `WasFound() bool` to the `DependencyStepResult` type so that same-package consumers can inspect whether the dependency was found during reconciliation. 