### PR TITLE
feat: ignore not found errors in step_end

### DIFF
--- a/step_end.go
+++ b/step_end.go
@@ -3,6 +3,7 @@ package ctrlfwk
 import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -31,7 +32,8 @@ func NewEndStep[
 				}
 
 				if changed {
-					if err = PatchCustomResourceStatus(ctx, reconciler); err != nil {
+					err := PatchCustomResourceStatus(ctx, reconciler)
+					if err != nil && !apierrors.IsNotFound(err) {
 						return ResultInError(errors.Wrap(err, "failed to update controller resource"))
 					}
 				}
@@ -83,7 +85,8 @@ func NewReadyConditionFinalStep[
 				return nil
 			}
 
-			if err = PatchCustomResourceStatus(ctx, reconciler); err != nil {
+			err = PatchCustomResourceStatus(ctx, reconciler)
+			if err != nil && !apierrors.IsNotFound(err) {
 				return errors.Wrap(err, "failed to update controller resource")
 			}
 


### PR DESCRIPTION
Currently, both `NewEndStep` and `NewReadyConditionFinalStep` return an error when `PatchCustomResourceStatus` fails with a NotFound error. This change silently ignores `NotFound` errors from `PatchCustomResourceStatus`.