### PR TITLE
feat(resource): add custom error handler

### DIFF
--- a/docs/docs/resources.md
+++ b/docs/docs/resources.md
@@ -76,6 +76,33 @@ ctrlfwk.NewReconcileResourcesStep(fwkCtx, reconciler)
 - `WithUserIdentifier(...)`
 - `WithCanBePaused(true)`
 - `WithCanBePausedFunc(...)`
+- `WithMutatorErrorHandler(...)`
+
+## Mutator error handling
+
+By default, errors from the `WithMutator` callback propagate directly to `CreateOrPatch`. Use `WithMutatorErrorHandler` to transform, log, or suppress them before they cause the step to fail.
+
+One common use case is ignoring transient errors caused by a namespace being terminated:
+
+```go
+type pausableResource struct{}
+
+func (p pausableResource) GetPausableResources(context.Context) ... {}
+
+ctrlfwk.NewResourceBuilder(ctx, &corev1.ConfigMap{}).
+    WithMutator(func(cm *corev1.ConfigMap) error {
+        return controllerutil.SetOwnerReference(ctx.GetCustomResource(), cm, reconciler.Scheme())
+    }).
+    WithMutatorErrorHandler(func(err error) error {
+        if apierrors.HasStatusCause(err, corev1.NamespaceTerminatingCause) {
+            return nil // ignore because the resource will be garbage-collected
+        }
+        return err
+    }).
+    Build()
+```
+
+The `WithMutatorErrorHandler` method is also available on `NewUntypedResourceBuilder`.
 
 ## Untyped resource builder
 

--- a/resource.go
+++ b/resource.go
@@ -21,6 +21,8 @@ type GenericResource[CustomResource client.Object, ContextType Context[CustomRes
 	ShouldDeleteNow() bool
 	// GetMutator returns the mutation function passed to controllerutil.CreateOrPatch.
 	GetMutator(obj client.Object) func() error
+	// HandleMutatorError is used to handle the errors of GetMutator, by default it simply returns the error as-is.
+	HandleMutatorError(error) error
 	// Set stores the reconciled resource object after create-or-patch.
 	Set(obj client.Object)
 	// Get returns the currently stored resource object.
@@ -57,9 +59,10 @@ type GenericResource[CustomResource client.Object, ContextType Context[CustomRes
 var _ GenericResource[client.Object, Context[client.Object]] = &Resource[client.Object, Context[client.Object], client.Object]{}
 
 type Resource[CustomResource client.Object, ContextType Context[CustomResource], ResourceType client.Object] struct {
-	userIdentifier string
-	keyF           func() types.NamespacedName
-	mutateF        Mutator[ResourceType]
+	userIdentifier      string
+	keyF                func() types.NamespacedName
+	mutateF             Mutator[ResourceType]
+	mutatorErrorHandler func(error) error
 
 	isReadyF          func(obj ResourceType) bool
 	shouldDeleteF     func() bool
@@ -253,6 +256,14 @@ func (c *Resource[CustomResource, ContextType, ResourceType]) GetMutator(obj cli
 		}
 		return nil
 	}
+}
+
+// HandleMutatorError is used to handle the errors of GetMutator, by default it simply returns the error as-is.
+func (c *Resource[CustomResource, ContextType, ResourceType]) HandleMutatorError(err error) error {
+	if c.mutatorErrorHandler != nil {
+		return c.mutatorErrorHandler(err)
+	}
+	return err
 }
 
 // CanBePaused reports whether pause-label checks should skip mutation for this resource.

--- a/resource_builder.go
+++ b/resource_builder.go
@@ -185,6 +185,38 @@ func (b *ResourceBuilder[CustomResource, ContextType, ResourceType]) WithMutator
 	return b
 }
 
+// WithMutatorErrorHandler configures a custom error handler for mutator errors.
+//
+// The handler receives errors returned by the mutator function passed to CreateOrPatch.
+// It can transform, log, or suppress them. By default mutator errors are returned as-is.
+//
+// Common use cases:
+//   - Treating specific mutator errors as non-fatal
+//   - Augmenting errors with additional context before bubbling up
+//   - Aggregating mutator errors for debugging
+//   - Ignoring NamespaceTerminating errors from mutators touching resources in terminating namespaces
+//
+// Example:
+//
+//	.WithMutatorErrorHandler(func(err error) error {
+//		if errors.Is(err, ErrNonFatalValidation) {
+//			return nil // swallow non-fatal errors
+//		}
+//		return fmt.Errorf("failed to mutate deployment: %w", err)
+//	})
+//
+//	.WithMutatorErrorHandler(func(err error) error {
+//		// Ignore errors caused by namespace termination
+//		if apierrors.HasStatusCause(err, corev1.NamespaceTerminatingCause) {
+//			return nil
+//		}
+//		return err
+//	})
+func (b *ResourceBuilder[CustomResource, ContextType, ResourceType]) WithMutatorErrorHandler(f func(error) error) *ResourceBuilder[CustomResource, ContextType, ResourceType] {
+	b.resource.mutatorErrorHandler = f
+	return b
+}
+
 // WithOutput specifies where to store the reconciled resource after successful operations.
 //
 // The provided object will be populated with the resource's current state from the

--- a/resource_builder_resources_test.go
+++ b/resource_builder_resources_test.go
@@ -229,6 +229,7 @@ func (earlyReturnResource) ID() string                                          
 func (earlyReturnResource) ObjectMetaGenerator() (client.Object, bool, error)            { return nil, true, nil }
 func (earlyReturnResource) ShouldDeleteNow() bool                                        { return true }
 func (earlyReturnResource) GetMutator(client.Object) func() error                        { return func() error { return nil } }
+func (earlyReturnResource) HandleMutatorError(err error) error                           { return err }
 func (earlyReturnResource) Set(client.Object)                                            {}
 func (earlyReturnResource) Get() client.Object                                           { return nil }
 func (earlyReturnResource) Kind() string                                                 { return "ConfigMap" }
@@ -241,6 +242,27 @@ func (earlyReturnResource) OnCreate(*resourceStepTestContext, client.Object) err
 func (earlyReturnResource) OnUpdate(*resourceStepTestContext, client.Object) error       { return nil }
 func (earlyReturnResource) OnDelete(*resourceStepTestContext, client.Object) error       { return nil }
 func (earlyReturnResource) OnFinalize(*resourceStepTestContext, client.Object) error     { return nil }
+
+func TestResourceBuilder_ConfiguresMutatorErrorHandler(t *testing.T) {
+	ctx := newTestContext()
+	handlerCalled := false
+	resource := ctrlfwk.NewResourceBuilder(ctx, &corev1.ConfigMap{}).
+		WithKey(types.NamespacedName{Name: "managed", Namespace: "default"}).
+		WithMutatorErrorHandler(func(err error) error {
+			handlerCalled = true
+			return errors.New("wrapped: " + err.Error())
+		}).
+		Build()
+
+	originalErr := errors.New("mutator failed")
+	handled := resource.HandleMutatorError(originalErr)
+	if want := "wrapped: mutator failed"; handled.Error() != want {
+		t.Fatalf("expected error %q, got %q", want, handled.Error())
+	}
+	if !handlerCalled {
+		t.Fatal("expected error handler to be invoked")
+	}
+}
 
 func TestReconcileResourcesStep_HandlesErrorsAndEarlyReturn(t *testing.T) {
 	scheme := runtime.NewScheme()

--- a/resource_untyped_builder.go
+++ b/resource_untyped_builder.go
@@ -406,6 +406,17 @@ func (b *UntypedResourceBuilder[CustomResource, ContextType]) WithMutator(f Muta
 	return b
 }
 
+// WithMutatorErrorHandler configures a custom error handler for mutator errors.
+//
+// The handler receives errors returned by the mutator function passed to CreateOrPatch.
+// It can transform, log, or suppress them. By default mutator errors are returned as-is.
+//
+// See the typed [ResourceBuilder.WithMutatorErrorHandler] for detailed examples.
+func (b *UntypedResourceBuilder[CustomResource, ContextType]) WithMutatorErrorHandler(f func(error) error) *UntypedResourceBuilder[CustomResource, ContextType] {
+	b.inner = b.inner.WithMutatorErrorHandler(f)
+	return b
+}
+
 // WithOutput specifies where to store the reconciled untyped resource after successful operations.
 //
 // The provided unstructured.Unstructured object will be populated with the resource's

--- a/resource_untyped_builder_test.go
+++ b/resource_untyped_builder_test.go
@@ -1,6 +1,7 @@
 package ctrlfwk_test
 
 import (
+	"errors"
 	"testing"
 
 	ctrlfwk "github.com/u-ctf/controller-fwk"
@@ -134,5 +135,25 @@ func TestUntypedResourceBuilder_ConfiguresWrappers(t *testing.T) {
 	}
 	if got := staticObj.(*unstructured.Unstructured); got.GetName() != "fixed" || got.GetNamespace() != "other" {
 		t.Fatalf("unexpected static untyped key: %s/%s", got.GetNamespace(), got.GetName())
+	}
+}
+
+func TestUntypedResourceBuilder_ConfiguresMutatorErrorHandler(t *testing.T) {
+	ctx := newTestContext()
+	handlerCalled := false
+	resource := ctrlfwk.NewUntypedResourceBuilder(ctx, schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "Widget"}).
+		WithMutatorErrorHandler(func(err error) error {
+			handlerCalled = true
+			return errors.New("wrapped: " + err.Error())
+		}).
+		Build()
+
+	originalErr := errors.New("mutator failed")
+	handled := resource.HandleMutatorError(originalErr)
+	if want := "wrapped: mutator failed"; handled.Error() != want {
+		t.Fatalf("expected error %q, got %q", want, handled.Error())
+	}
+	if !handlerCalled {
+		t.Fatal("expected error handler to be invoked")
 	}
 }

--- a/step_resource.go
+++ b/step_resource.go
@@ -103,10 +103,13 @@ func NewReconcileResourceStep[
 							}
 						}
 
-						return wrappedFunc()
+						return resource.HandleMutatorError(wrappedFunc())
 					}
 				} else {
-					mutator = resource.GetMutator(desired)
+					wrappedFunc := resource.GetMutator(desired)
+					mutator = func() error {
+						return resource.HandleMutatorError(wrappedFunc())
+					}
 				}
 
 				patchResult, err := controllerutil.CreateOrPatch(ctx, reconciler, desired, mutator)

--- a/step_resource_lifecycle_test.go
+++ b/step_resource_lifecycle_test.go
@@ -1,6 +1,8 @@
 package ctrlfwk_test
 
 import (
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -197,4 +199,67 @@ func TestNewReconcileResourceStep_FinalizationPaths(t *testing.T) {
 			t.Fatalf("expected managed resource to be deleted during finalization, got %v", err)
 		}
 	})
+}
+
+func TestNewReconcileResourceStep_MutatorErrorHandlerTransformsError(t *testing.T) {
+	scheme := newResourceScheme(t)
+	cr := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "controller", Namespace: "default"}}
+	reconciler := fakeResourceReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(cr).Build()}
+	ctx := newResourceStepTestContext()
+	ctx.SetCustomResource(cr)
+
+	resource := ctrlfwk.NewResourceBuilder(ctx, &corev1.ConfigMap{}).
+		WithKey(types.NamespacedName{Name: "managed", Namespace: "default"}).
+		WithMutator(func(cm *corev1.ConfigMap) error {
+			return errors.New("original mutator error")
+		}).
+		WithMutatorErrorHandler(func(err error) error {
+			return errors.New("transformed error")
+		}).
+		Build()
+
+	result := ctrlfwk.NewReconcileResourceStep(ctx, reconciler, resource).Step(ctx, logr.Discard(), ctrl.Request{})
+	if result.Error() == nil {
+		t.Fatal("expected error from reconciliation")
+	}
+	if !strings.Contains(result.Error().Error(), "transformed error") {
+		t.Fatalf("expected transformed error in result, got %q", result.Error().Error())
+	}
+}
+
+func TestNewReconcileResourceStep_MutatorErrorHandlerCanSwallowError(t *testing.T) {
+	scheme := newResourceScheme(t)
+	cr := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "controller", Namespace: "default"}}
+	reconciler := fakeResourceReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(cr).Build()}
+	ctx := newResourceStepTestContext()
+	ctx.SetCustomResource(cr)
+
+	afterCalled := false
+	resource := ctrlfwk.NewResourceBuilder(ctx, &corev1.ConfigMap{}).
+		WithKey(types.NamespacedName{Name: "managed", Namespace: "default"}).
+		WithMutator(func(cm *corev1.ConfigMap) error {
+			return errors.New("should be swallowed")
+		}).
+		WithMutatorErrorHandler(func(err error) error {
+			return nil // swallow the error, reconciliation continues
+		}).
+		WithAfterReconcile(func(_ *resourceStepTestContext, cm *corev1.ConfigMap) error {
+			afterCalled = cm != nil
+			return nil
+		}).
+		Build()
+
+	result := ctrlfwk.NewReconcileResourceStep(ctx, reconciler, resource).Step(ctx, logr.Discard(), ctrl.Request{})
+	if result.Error() != nil {
+		t.Fatalf("expected swallowed mutator error to succeed, got %v", result.Error())
+	}
+	if !afterCalled {
+		t.Fatal("expected AfterReconcile to run when mutator error is swallowed")
+	}
+
+	// Verify the resource was actually created despite the swallowed mutator error
+	stored := &corev1.ConfigMap{}
+	if err := reconciler.Get(ctx, client.ObjectKey{Name: "managed", Namespace: "default"}, stored); err != nil {
+		t.Fatalf("expected resource to be created even when mutator error is swallowed, got %v", err)
+	}
 }

--- a/utils.go
+++ b/utils.go
@@ -1,7 +1,15 @@
 package ctrlfwk
 
-import "sigs.k8s.io/controller-runtime/pkg/client"
+import (
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 func IsFinalizing(obj client.Object) bool {
 	return !obj.GetDeletionTimestamp().IsZero()
+}
+
+func IsNamespaceTerminating(err error) bool {
+	return apierrors.HasStatusCause(err, corev1.NamespaceTerminatingCause)
 }


### PR DESCRIPTION
## What

This MR introduces `WithMutatorErrorHandler` to both the typed and untyped resource builders, allowing controllers to transform, log, or suppress errors returned by `WithMutator` before they cause `CreateOrPatch` to fail.

## Why

Mutators occasionally hit transient errors such as `NamespaceTerminating` when setting owner references or applying labels to a resource that lives in a namespace being deleted. Errors originating *inside* the mutator callback itself (e.g. `controllerutil.SetOwnerReference`) would bubble up and fail the step.

This change makes the per-resource mutator error handling explicit, configurable, and extensible.

## Changes

| File | Change |
|---|---|
| `resource.go` | Adds `HandleMutatorError(error) error` to `GenericResource` interface; implements identity default on `Resource` |
| `resource_builder.go` | Adds `WithMutatorErrorHandler(f func(error) error)` to typed builder |
| `resource_untyped_builder.go` | Adds `WithMutatorErrorHandler(f func(error) error)` to untyped builder |
| `step_resource.go` | Wraps `GetMutator` so errors pass through `resource.HandleMutatorError` before reaching `CreateOrPatch` |
| `utils.go` | Adds `IsNamespaceTerminating(err error) bool` helper |
| `docs/docs/resources.md` | Documents new method with `NamespaceTerminating` example |
| Test files | Covers handler invocation, error transformation, and error swallowing in both builder and step tests |

## Example

```go
ctrlfwk.NewResourceBuilder(ctx, &corev1.ConfigMap{}).
    WithMutator(func(cm *corev1.ConfigMap) error {
        return controllerutil.SetOwnerReference(cr, cm, scheme)
    }).
    WithMutatorErrorHandler(func(err error) error {
        if ctrlfwk.IsNamespaceTerminating(err) {
            return nil // resource will be garbage-collected anyway
        }
        return err
    }).
    Build()
```

## Backward compatibility

- Default behavior is unchanged: `HandleMutatorError` returns the error as-is when no handler is configured.
- Existing implementations of `GenericResource` need to add `HandleMutatorError(error) error` to satisfy the interface.
